### PR TITLE
rate limiting that actually works (again) + poll persistence

### DIFF
--- a/Pollcord/client.py
+++ b/Pollcord/client.py
@@ -8,6 +8,7 @@ import aiohttp
 
 from Pollcord.poll import Poll
 from Pollcord.voter import Voter
+from Pollcord.rate_limiter import RateLimiter
 from Pollcord.error import PollCreationError, PollNotFoundError, PollcordError
 
 
@@ -15,19 +16,24 @@ class PollClient:
     logger = logging.getLogger("pollcord")
     BASE_URL = "https://discord.com/api/v10"
 
-    def __init__(self, token: str):
+    def __init__(self, token: str, max_retries: int = 5):
         """
-        Initializes the PollClient with a bot token for authorization.
+        Initializes the PollClient.
 
         Parameters:
-            token (str): Your Discord bot token.
+            token (str):       Your Discord bot token.
+            max_retries (int): Maximum retries per request before raising
+                               PollcordError. Applies to all requests made
+                               by this client. Default: 5.
         """
         self.token = token
+        self.max_retries = max_retries
         self.headers = {
             "Authorization": f"Bot {token}",
             "Content-Type": "application/json",
         }
         self.session: Optional[aiohttp.ClientSession] = None
+        self._rate_limiter: Optional[RateLimiter] = None
         self.logger.info(f"Initialized PollClient: {self!r}")
 
     def __repr__(self) -> str:
@@ -35,6 +41,11 @@ class PollClient:
 
     async def __aenter__(self) -> "PollClient":
         self.session = aiohttp.ClientSession(headers=self.headers)
+        self._rate_limiter = RateLimiter(
+            session=self.session,
+            max_retries=self.max_retries,
+        )
+        self._rate_limiter.start()
         return self
 
     async def __aexit__(self, exc_type, exc, tb) -> None:
@@ -52,19 +63,17 @@ class PollClient:
         duration: int = 1,
         isMultiselect: bool = False,
         callback: Optional[Callable] = None,
-        max_retries: int = 5,
     ) -> Poll:
         """
         Creates a poll in a Discord channel.
 
         Parameters:
-            channel_id (int): The channel to post the poll in.
-            question (str): The poll question.
-            options (List[str]): Answer choices (2–10 items).
-            duration (int): Poll duration in hours.
+            channel_id (int):     The channel to post the poll in.
+            question (str):       The poll question.
+            options (List[str]):  Answer choices (2-10 items).
+            duration (int):       Poll duration in hours.
             isMultiselect (bool): Allow multiple votes per user.
-            callback (Callable): Called when the poll ends.
-            max_retries (int): Max retries on rate limit.
+            callback (Callable):  Called when the poll ends.
 
         Returns:
             Poll: The created poll object.
@@ -96,9 +105,7 @@ class PollClient:
             f"options={options} duration={duration}h multiselect={isMultiselect}"
         )
 
-        status, response = await self._request(
-            "POST", url, payload=payload, max_retries=max_retries
-        )
+        status, response = await self._request("POST", url, payload=payload)
 
         if status not in (200, 201):
             self.logger.error(f"Failed to create poll: {status} - {response}")
@@ -127,7 +134,8 @@ class PollClient:
         """
         self.logger.debug(f"Fetching vote users for poll {poll.message_id}")
         tasks = [
-            self.fetch_option_users(poll, index) for index in range(len(poll.options))
+            self.fetch_option_users(poll, index)
+            for index in range(len(poll.options))
         ]
         return list(await asyncio.gather(*tasks))
 
@@ -146,72 +154,77 @@ class PollClient:
         self,
         poll: Poll,
         answer_index: int,
-        max_retries: int = 5,
     ) -> List[Voter]:
         """
         Fetches voters for a single answer option.
 
         Parameters:
-            poll (Poll): The poll to query.
+            poll (Poll):        The poll to query.
             answer_index (int): Zero-based index of the answer option.
-            max_retries (int): Max retries on rate limit.
 
         Returns:
             List[Voter]: Users who voted for this option.
 
         Raises:
             PollNotFoundError: If the poll/channel cannot be found (404).
-            PollcordError: On any other API error.
+            PollcordError:     On any other API error.
         """
         url = (
             f"{self.BASE_URL}/channels/{poll.channel_id}"
             f"/polls/{poll.message_id}/answers/{answer_index + 1}"
         )
-        status, response = await self._request("GET", url, max_retries=max_retries)
+        status, response = await self._request("GET", url)
 
         if status == 404:
             self.logger.error(f"Poll not found ({poll.message_id}): {response}")
             raise PollNotFoundError(response, poll=poll)
         elif status != 200:
-            self.logger.error(
-                f"Error fetching poll voters ({poll.message_id}): {response}"
-            )
+            self.logger.error(f"Error fetching poll voters ({poll.message_id}): {response}")
             raise PollcordError(response, poll=poll)
 
         raw_users = response.get("users", [])
         return [Voter.from_dict(u) for u in raw_users]
 
-    async def end_poll(self, poll: Poll, max_retries: int = 5) -> None:
+    async def end_poll(self, poll: Poll) -> None:
         """
         Ends a poll via the Discord API, then marks it ended locally.
 
         Parameters:
             poll (Poll): The poll to end.
-            max_retries (int): Max retries on rate limit.
 
         Raises:
             PollNotFoundError: If the poll cannot be found.
-            PollcordError: On any other API error.
+            PollcordError:     On any other API error.
         """
         url = (
-            f"{self.BASE_URL}/channels/{poll.channel_id}/polls/{poll.message_id}/expire"
+            f"{self.BASE_URL}/channels/{poll.channel_id}"
+            f"/polls/{poll.message_id}/expire"
         )
         self.logger.debug(f"Ending poll {poll.message_id} via API")
 
-        status, response = await self._request("POST", url, max_retries=max_retries)
+        status, response = await self._request("POST", url)
 
         if status == 404:
-            raise PollNotFoundError(f"Poll not found: {status} - {response}", poll=poll)
+            raise PollNotFoundError(
+                f"Poll not found: {status} - {response}", poll=poll
+            )
         elif status not in (200, 204):
-            raise PollcordError(f"Failed to end poll: {status} - {response}", poll=poll)
+            raise PollcordError(
+                f"Failed to end poll: {status} - {response}", poll=poll
+            )
 
         await poll.end()
 
     async def close(self) -> None:
-        """Manually close the aiohttp session."""
+        """Shut down the rate limiter and close the HTTP session."""
+        if self._rate_limiter:
+            await self._rate_limiter.stop()
+            self._rate_limiter = None
+
         if self.session and not self.session.closed:
             self.logger.info("Closing PollClient HTTP session")
             await self.session.close()
+            self.session = None
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -222,58 +235,33 @@ class PollClient:
         method: str,
         url: str,
         payload: Optional[dict] = None,
-        max_retries: int = 5,
     ) -> tuple[int, any]:
         """
-        Performs an HTTP request with built-in rate limit handling.
+        Submit a request through the rate limiter.
 
         Parameters:
-            method (str): HTTP verb — 'GET' or 'POST'.
-            url (str): The endpoint URL.
-            payload (dict, optional): JSON body for POST requests.
-            max_retries (int): Maximum number of retries after a 429.
+            method:  HTTP verb - 'GET' or 'POST'.
+            url:     The endpoint URL.
+            payload: JSON body for POST requests.
 
         Returns:
             Tuple[int, any]: (status_code, parsed_response)
 
         Raises:
-            RuntimeError: If the session has not been initialised.
+            RuntimeError:  If the session has not been initialised.
             PollcordError: If max retries are exceeded.
         """
-        if not self.session:
+        if not self._rate_limiter:
             raise RuntimeError(
                 "PollClient session is not initialised. "
-                "Use it as an async context manager: `async with PollClient(...) as client:`"
+                "Use it as an async context manager: "
+                "`async with PollClient(...) as client:`"
             )
-
-        self.logger.info(f"{method} {url}")
-
-        for attempt in range(max_retries):
-            async with self.session.request(method, url, json=payload) as response:
-                if response.status == 429:
-                    data = await response.json()
-                    wait_time = data.get("retry_after", 1.0)
-                    self.logger.warning(
-                        f"Rate limited (429). Waiting {wait_time}s "
-                        f"(attempt {attempt + 1}/{max_retries})"
-                    )
-                    await asyncio.sleep(wait_time)
-                    continue
-
-                try:
-                    data = await response.json()
-                except Exception:
-                    data = await response.text()
-
-                return response.status, data
-
-        raise PollcordError(
-            f"Exceeded maximum retries ({max_retries}) due to rate limiting on {url}"
-        )
+        return await self._rate_limiter.submit(method, url, payload)
 
     @staticmethod
     def _format_options(options: List[str]) -> List[dict]:
         return [
-            {"answer_id": str(i + 1), "poll_media": {"text": str(opt)}}
+            {"answer_id": i + 1, "poll_media": {"text": str(opt)}}
             for i, opt in enumerate(options)
         ]

--- a/Pollcord/rate_limiter.py
+++ b/Pollcord/rate_limiter.py
@@ -1,0 +1,405 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+from Pollcord.error import PollcordError
+
+logger = logging.getLogger("pollcord.ratelimiter")
+
+
+# ---------------------------------------------------------------------------
+# Request job
+# ---------------------------------------------------------------------------
+
+@dataclass
+class RequestJob:
+    """
+    A single HTTP request waiting to be dispatched.
+
+    Attributes:
+        method:      HTTP verb ('GET' or 'POST').
+        url:         Full endpoint URL.
+        payload:     JSON body for POST requests, or None.
+        future:      Resolved with (status, data) on success, or an exception.
+        retry_count: How many times this specific job has been retried after a 429.
+    """
+    method: str
+    url: str
+    payload: Optional[dict]
+    future: asyncio.Future
+    retry_count: int = 0
+
+
+# ---------------------------------------------------------------------------
+# Per-bucket state
+# ---------------------------------------------------------------------------
+
+@dataclass
+class RateLimitBucket:
+    """
+    Tracks the rate limit state for a single Discord bucket.
+
+    Attributes:
+        bucket_id:   The opaque hash Discord sends in X-RateLimit-Bucket.
+        remaining:   Requests remaining in the current window.
+        reset_after: Seconds until the window resets.
+        lock:        Ensures only one coroutine updates bucket state at a time.
+        queue:       Pending jobs routed to this bucket.
+        worker_task: The background coroutine draining this bucket's queue.
+    """
+    bucket_id: str
+    remaining: int = 1
+    reset_after: float = 0.0
+    limit: int = 1          # total requests allowed per window (X-RateLimit-Limit)
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    queue: asyncio.Queue = field(default_factory=asyncio.Queue)
+    worker_task: Optional[asyncio.Task] = field(default=None, compare=False)
+
+    def update_from_headers(self, headers: dict) -> None:
+        """Update bucket state from Discord response headers."""
+        try:
+            self.remaining = int(headers.get("X-RateLimit-Remaining", self.remaining))
+            self.reset_after = float(headers.get("X-RateLimit-Reset-After", 0.0))
+            self.limit = int(headers.get("X-RateLimit-Limit", self.limit))
+        except (ValueError, TypeError):
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Rate limiter
+# ---------------------------------------------------------------------------
+
+class RateLimiter:
+    """
+    Manages all HTTP traffic through Discord's rate limit system.
+
+    Each Discord rate limit bucket gets its own queue and worker coroutine.
+    The first request to an unknown route is sent solo to discover its bucket,
+    then subsequent requests to that route are dispatched concurrently up to
+    the bucket's remaining limit.
+
+    Retry logic lives here, not in the caller. Each RequestJob tracks its own
+    retry_count independently — a 429 on one job does not consume retries on
+    any other job.
+    """
+
+    def __init__(self, session: Any, max_retries: int = 5):
+        """
+        Parameters:
+            session:     An active aiohttp.ClientSession.
+            max_retries: Maximum retries per individual request job before
+                         raising PollcordError.
+        """
+        self._session = session
+        self._max_retries = max_retries
+
+        # Maps URL -> bucket_id (populated after first request to each route)
+        self._url_to_bucket: Dict[str, str] = {}
+
+        # Maps bucket_id -> RateLimitBucket
+        self._buckets: Dict[str, RateLimitBucket] = {}
+
+        # Holds jobs whose route has no known bucket yet.
+        # These are dispatched one at a time to safely discover the bucket.
+        self._unknown_queue: asyncio.Queue = asyncio.Queue()
+        self._unknown_worker_task: Optional[asyncio.Task] = None
+
+        # Set to a future timestamp when a global rate limit is hit.
+        # Bucket workers check this before dispatching.
+        self._global_pause_until: float = 0.0
+
+        self._running = False
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def start(self) -> None:
+        """Start the unknown-route worker. Call this when the session opens."""
+        self._running = True
+        self._unknown_worker_task = asyncio.get_event_loop().create_task(
+            self._unknown_worker(), name="ratelimiter:unknown"
+        )
+        logger.debug("RateLimiter started")
+
+    async def stop(self) -> None:
+        """Drain queues and shut down all workers. Call this when the session closes."""
+        self._running = False
+
+        # Cancel the unknown worker
+        if self._unknown_worker_task and not self._unknown_worker_task.done():
+            self._unknown_worker_task.cancel()
+            try:
+                await self._unknown_worker_task
+            except asyncio.CancelledError:
+                pass
+
+        # Cancel all bucket workers
+        for bucket in self._buckets.values():
+            if bucket.worker_task and not bucket.worker_task.done():
+                bucket.worker_task.cancel()
+                try:
+                    await bucket.worker_task
+                except asyncio.CancelledError:
+                    pass
+
+        logger.debug("RateLimiter stopped")
+
+    # ------------------------------------------------------------------
+    # Public submission
+    # ------------------------------------------------------------------
+
+    async def submit(
+        self,
+        method: str,
+        url: str,
+        payload: Optional[dict] = None,
+    ) -> tuple[int, Any]:
+        """
+        Submit a request and await its result.
+
+        Routes the job to either the known bucket queue or the unknown queue
+        depending on whether we have seen this URL before.
+
+        Parameters:
+            method:  HTTP verb.
+            url:     Full endpoint URL.
+            payload: JSON body for POST requests.
+
+        Returns:
+            Tuple of (status_code, response_data).
+
+        Raises:
+            PollcordError: If max retries are exceeded for this job.
+        """
+        loop = asyncio.get_event_loop()
+        future: asyncio.Future = loop.create_future()
+        job = RequestJob(method=method, url=url, payload=payload, future=future)
+
+        bucket_id = self._url_to_bucket.get(url)
+        if bucket_id and bucket_id in self._buckets:
+            logger.debug(f"Routing {method} {url} to known bucket {bucket_id!r}")
+            await self._buckets[bucket_id].queue.put(job)
+        else:
+            logger.debug(f"Routing {method} {url} to unknown queue (first contact)")
+            await self._unknown_queue.put(job)
+
+        return await future
+
+    # ------------------------------------------------------------------
+    # Unknown-route worker
+    # ------------------------------------------------------------------
+
+    async def _unknown_worker(self) -> None:
+        """
+        Processes jobs whose bucket is not yet known, one at a time.
+
+        After each response, registers the bucket and hands off to the
+        appropriate bucket worker for all future requests to that route.
+        """
+        while self._running:
+            try:
+                job: RequestJob = await asyncio.wait_for(
+                    self._unknown_queue.get(), timeout=1.0
+                )
+            except asyncio.TimeoutError:
+                continue
+
+            await self._dispatch_single(job, register_bucket=True)
+            self._unknown_queue.task_done()
+
+    # ------------------------------------------------------------------
+    # Bucket workers
+    # ------------------------------------------------------------------
+
+    def _ensure_bucket_worker(self, bucket: RateLimitBucket) -> None:
+        """Start a worker for this bucket if one isn't already running."""
+        if bucket.worker_task is None or bucket.worker_task.done():
+            bucket.worker_task = asyncio.get_event_loop().create_task(
+                self._bucket_worker(bucket),
+                name=f"ratelimiter:bucket:{bucket.bucket_id}"
+            )
+
+    async def _bucket_worker(self, bucket: RateLimitBucket) -> None:
+        """
+        Drains a single bucket's queue with proper concurrency.
+
+        Fires up to `bucket.remaining` jobs concurrently. If remaining hits 0,
+        waits for `reset_after` seconds before continuing.
+        """
+        while self._running:
+            try:
+                # Block until at least one job is available
+                first_job: RequestJob = await asyncio.wait_for(
+                    bucket.queue.get(), timeout=1.0
+                )
+            except asyncio.TimeoutError:
+                continue
+
+            # Respect global rate limit pause before dispatching anything
+            now = asyncio.get_event_loop().time()
+            if self._global_pause_until > now:
+                wait = self._global_pause_until - now
+                logger.debug(
+                    f"Bucket {bucket.bucket_id!r} waiting {wait:.2f}s for global pause"
+                )
+                await asyncio.sleep(wait)
+
+            async with bucket.lock:
+                # Collect a batch: the first job plus however many more
+                # we can send within the remaining limit
+                batch = [first_job]
+                slots = max(0, bucket.remaining - 1)
+
+                while slots > 0 and not bucket.queue.empty():
+                    try:
+                        batch.append(bucket.queue.get_nowait())
+                        slots -= 1
+                    except asyncio.QueueEmpty:
+                        break
+
+                logger.debug(
+                    f"Bucket {bucket.bucket_id!r}: dispatching batch of "
+                    f"{len(batch)} (remaining={bucket.remaining})"
+                )
+
+                # Fire the batch concurrently
+                await asyncio.gather(
+                    *[self._dispatch_single(job, bucket=bucket) for job in batch]
+                )
+
+                for _ in batch:
+                    bucket.queue.task_done()
+
+                # If the window is exhausted, wait for reset
+                if bucket.remaining == 0 and bucket.reset_after > 0:
+                    logger.debug(
+                        f"Bucket {bucket.bucket_id!r} exhausted. "
+                        f"Waiting {bucket.reset_after}s for reset."
+                    )
+                    await asyncio.sleep(bucket.reset_after)
+                    bucket.remaining = bucket.limit  # restore full window
+
+    # ------------------------------------------------------------------
+    # Core dispatch
+    # ------------------------------------------------------------------
+
+    async def _dispatch_single(
+        self,
+        job: RequestJob,
+        bucket: Optional[RateLimitBucket] = None,
+        register_bucket: bool = False,
+    ) -> None:
+        """
+        Executes one HTTP request and resolves the job's future.
+
+        On 429: increments job.retry_count, sleeps retry_after, then requeues.
+        On success: resolves the future with (status, data).
+        On fatal error: resolves the future with a PollcordError exception.
+
+        Parameters:
+            job:              The request to execute.
+            bucket:           Known bucket for this job, if any.
+            register_bucket:  If True, register the bucket from response headers.
+        """
+        if job.retry_count >= self._max_retries:
+            job.future.set_exception(
+                PollcordError(
+                    f"Exceeded maximum retries ({self._max_retries}) for "
+                    f"{job.method} {job.url}"
+                )
+            )
+            return
+
+        try:
+            async with self._session.request(
+                job.method, job.url, json=job.payload
+            ) as response:
+                headers = dict(response.headers)
+
+                # Register or update bucket from headers
+                incoming_bucket_id = headers.get("X-RateLimit-Bucket")
+                if incoming_bucket_id:
+                    if register_bucket or job.url not in self._url_to_bucket:
+                        self._register_bucket(job.url, incoming_bucket_id, headers)
+                    elif bucket:
+                        bucket.update_from_headers(headers)
+
+                if response.status == 429:
+                    try:
+                        data = await response.json()
+                        retry_after = float(data.get("retry_after", 1.0))
+                    except Exception:
+                        retry_after = 1.0
+
+                    is_global = headers.get("X-RateLimit-Global", "false").lower() == "true"
+                    scope = "global" if is_global else f"bucket {incoming_bucket_id!r}"
+                    job.retry_count += 1
+
+                    logger.warning(
+                        f"429 on {job.method} {job.url} ({scope}). "
+                        f"retry_after={retry_after}s "
+                        f"(attempt {job.retry_count}/{self._max_retries})"
+                    )
+
+                    if is_global:
+                        # Global rate limit: pause ALL bucket workers by holding
+                        # their locks simultaneously would be complex, so instead
+                        # we sleep here (blocking this coroutine) and let the
+                        # bucket workers naturally drain while waiting for jobs.
+                        logger.warning(
+                            f"Global rate limit hit. Pausing {retry_after}s."
+                        )
+                        self._global_pause_until = asyncio.get_event_loop().time() + retry_after
+
+                    await asyncio.sleep(retry_after)
+
+                    # Requeue to the appropriate destination
+                    target_bucket_id = self._url_to_bucket.get(job.url)
+                    if target_bucket_id and target_bucket_id in self._buckets:
+                        await self._buckets[target_bucket_id].queue.put(job)
+                    else:
+                        await self._unknown_queue.put(job)
+                    return
+
+                # Success path — parse and resolve
+                try:
+                    data = await response.json()
+                except Exception:
+                    data = await response.text()
+
+                if not job.future.done():
+                    job.future.set_result((response.status, data))
+
+        except Exception as exc:
+            if not job.future.done():
+                job.future.set_exception(exc)
+
+    # ------------------------------------------------------------------
+    # Bucket registration
+    # ------------------------------------------------------------------
+
+    def _register_bucket(
+        self, url: str, bucket_id: str, headers: dict
+    ) -> None:
+        """
+        Register or update a bucket from response headers.
+
+        If the bucket is new, creates it and starts its worker.
+        """
+        self._url_to_bucket[url] = bucket_id
+
+        if bucket_id not in self._buckets:
+            bucket = RateLimitBucket(bucket_id=bucket_id)
+            bucket.update_from_headers(headers)
+            self._buckets[bucket_id] = bucket
+            self._ensure_bucket_worker(bucket)
+            logger.debug(
+                f"Registered new bucket {bucket_id!r} for {url} "
+                f"(remaining={bucket.remaining}, reset_after={bucket.reset_after}s)"
+            )
+        else:
+            self._buckets[bucket_id].update_from_headers(headers)

--- a/tests/test_rate_limiting.py
+++ b/tests/test_rate_limiting.py
@@ -1,129 +1,425 @@
+"""
+Tests for the RateLimiter and bucket-aware request queuing.
+
+These tests mock aiohttp at the session level so no real HTTP requests are made.
+"""
 import asyncio
 import pytest
-from unittest.mock import patch
-from aioresponses import aioresponses
-from Pollcord import PollClient, Poll
+from unittest.mock import AsyncMock, MagicMock
+from Pollcord.rate_limiter import RateLimiter, RequestJob, RateLimitBucket
 from Pollcord.error import PollcordError
 
 
-@pytest.fixture
-def poll():
-    return Poll(
-        channel_id=12345,
-        message_id=99999,
-        prompt="Rate limit test",
-        options=["A", "B", "C"],
-        duration=1,
-        on_end=None,
-    )
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
 
-
-@pytest.mark.asyncio
-async def test_rate_limit_retries_and_succeeds(poll):
-    """A 429 response should be retried and ultimately succeed."""
-    url = (
-        f"https://discord.com/api/v10/channels/{poll.channel_id}"
-        f"/polls/{poll.message_id}/answers/1"
-    )
-    success_payload = {
-        "users": [{"id": "1", "username": "alice", "discriminator": "0"}]
+def headers_with_remaining(n: int) -> dict[str, str]:
+    return {
+        "X-RateLimit-Bucket": "bucket-batch",
+        "X-RateLimit-Remaining": str(n),
+        "X-RateLimit-Reset-After": "0.05",
     }
 
-    with aioresponses() as m:
-        # First call: rate limited
-        m.get(url, status=429, payload={"retry_after": 0.01})
-        # Second call: success
-        m.get(url, status=200, payload=success_payload)
+def make_mock_response(
+    status: int,
+    json_data: dict = None,
+    text_data: str = "",
+    headers: dict = None,
+):
+    """Build a mock aiohttp response."""
+    response = MagicMock()
+    response.status = status
+    response.headers = headers or {}
 
-        async with PollClient(token="fake_token") as client:
-            voters = await client.fetch_option_users(poll, 0)
+    if json_data is not None:
+        response.json = AsyncMock(return_value=json_data)
+    else:
+        response.json = AsyncMock(side_effect=Exception("no json"))
 
-    assert len(voters) == 1
-    assert voters[0].username == "alice"
+    response.text = AsyncMock(return_value=text_data)
+    response.__aenter__ = AsyncMock(return_value=response)
+    response.__aexit__ = AsyncMock(return_value=False)
+    return response
 
+
+def make_session(*responses):
+    """
+    Build a mock aiohttp session that returns the given responses in order.
+    Each element of responses should be a mock response object.
+    """
+    session = MagicMock()
+    session.request = MagicMock(side_effect=[
+        MagicMock(
+            __aenter__=AsyncMock(return_value=r),
+            __aexit__=AsyncMock(return_value=False),
+        )
+        for r in responses
+    ])
+    return session
+
+
+# ---------------------------------------------------------------------------
+# RequestJob
+# ---------------------------------------------------------------------------
+
+def test_request_job_defaults():
+    loop = asyncio.new_event_loop()
+    future = loop.create_future()
+    job = RequestJob(method="GET", url="http://example.com", payload=None, future=future)
+    assert job.retry_count == 0
+    loop.close()
+
+
+# ---------------------------------------------------------------------------
+# RateLimitBucket
+# ---------------------------------------------------------------------------
+
+def test_bucket_update_from_headers():
+    bucket = RateLimitBucket(bucket_id="abc")
+    bucket.update_from_headers({
+        "X-RateLimit-Remaining": "4",
+        "X-RateLimit-Reset-After": "0.5",
+        "X-RateLimit-Limit": "10",
+    })
+    assert bucket.remaining == 4
+    assert bucket.reset_after == 0.5
+    assert bucket.limit == 10
+
+
+def test_bucket_update_ignores_bad_headers():
+    bucket = RateLimitBucket(bucket_id="abc", remaining=3, limit=10)
+    bucket.update_from_headers({
+        "X-RateLimit-Remaining": "not-a-number",
+    })
+    # Should not crash and should leave remaining and limit unchanged
+    assert bucket.remaining == 3
+    assert bucket.limit == 10
+
+
+# ---------------------------------------------------------------------------
+# Basic submit / dispatch
+# ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
-async def test_rate_limit_exhausts_retries(poll):
-    """Exceeding max_retries on 429 should raise PollcordError."""
-    url = (
-        f"https://discord.com/api/v10/channels/{poll.channel_id}"
-        f"/polls/{poll.message_id}/answers/1"
-    )
-
-    with aioresponses() as m:
-        # Always rate limited
-        for _ in range(3):
-            m.get(url, status=429, payload={"retry_after": 0.01})
-
-        async with PollClient(token="fake_token") as client:
-            with pytest.raises(PollcordError, match="Exceeded maximum retries"):
-                await client.fetch_option_users(poll, 0, max_retries=3)
-
-
-@pytest.mark.asyncio
-async def test_get_vote_users_fetches_concurrently(poll):
-    """get_vote_users should fire all option requests concurrently via gather."""
-
-    call_order = []
-
-    async def mock_fetch(p, index, **kwargs):
-        call_order.append(index)
-        await asyncio.sleep(0)  # yield to event loop
-        return []
-
-    async with PollClient(token="fake_token") as client:
-        with patch.object(client, "fetch_option_users", side_effect=mock_fetch):
-            await client.get_vote_users(poll)
-
-    # All three options should have been requested
-    assert sorted(call_order) == [0, 1, 2]
-
-
-@pytest.mark.asyncio
-async def test_get_vote_counts_matches_user_counts(poll):
-    """get_vote_counts should return lengths matching get_vote_users results."""
-    base = (
-        f"https://discord.com/api/v10/channels/{poll.channel_id}"
-        f"/polls/{poll.message_id}"
-    )
-    responses = [
-        {
-            "users": [
-                {"id": "1", "username": "a", "discriminator": "0"},
-                {"id": "2", "username": "b", "discriminator": "0"},
-            ]
+async def test_submit_success_unknown_route():
+    """A request on an unknown route goes through the unknown worker and succeeds."""
+    response = make_mock_response(
+        status=200,
+        json_data={"ok": True},
+        headers={
+            "X-RateLimit-Bucket": "bucket-abc",
+            "X-RateLimit-Remaining": "4",
+            "X-RateLimit-Reset-After": "1.0",
         },
-        {"users": [{"id": "3", "username": "c", "discriminator": "0"}]},
-        {"users": []},
+    )
+    session = make_session(response)
+
+    limiter = RateLimiter(session=session, max_retries=3)
+    limiter.start()
+
+    try:
+        status, data = await asyncio.wait_for(
+            limiter.submit("GET", "https://discord.com/api/v10/test"),
+            timeout=5.0,
+        )
+    finally:
+        await limiter.stop()
+
+    assert status == 200
+    assert data == {"ok": True}
+
+
+@pytest.mark.asyncio
+async def test_bucket_registered_after_first_request():
+    """After the first request, the URL should be mapped to the bucket ID."""
+    response = make_mock_response(
+        status=200,
+        json_data={},
+        headers={
+            "X-RateLimit-Bucket": "bucket-xyz",
+            "X-RateLimit-Remaining": "2",
+            "X-RateLimit-Reset-After": "0.5",
+        },
+    )
+    session = make_session(response)
+    limiter = RateLimiter(session=session, max_retries=3)
+    limiter.start()
+
+    try:
+        await asyncio.wait_for(
+            limiter.submit("GET", "https://discord.com/api/v10/channels/1/test"),
+            timeout=5.0,
+        )
+    finally:
+        await limiter.stop()
+
+    assert limiter._url_to_bucket.get("https://discord.com/api/v10/channels/1/test") == "bucket-xyz"
+    assert "bucket-xyz" in limiter._buckets
+    assert limiter._buckets["bucket-xyz"].remaining == 2
+
+
+@pytest.mark.asyncio
+async def test_known_route_goes_to_bucket_queue():
+    """A second request to a known route is routed to the bucket queue, not unknown."""
+    url = "https://discord.com/api/v10/channels/1/messages"
+    headers = {
+        "X-RateLimit-Bucket": "bucket-123",
+        "X-RateLimit-Remaining": "4",
+        "X-RateLimit-Reset-After": "1.0",
+    }
+    r1 = make_mock_response(200, json_data={"id": "1"}, headers=headers)
+    r2 = make_mock_response(200, json_data={"id": "2"}, headers=headers)
+    session = make_session(r1, r2)
+
+    limiter = RateLimiter(session=session, max_retries=3)
+    limiter.start()
+
+    try:
+        await asyncio.wait_for(limiter.submit("POST", url, {"a": 1}), timeout=5.0)
+        # Second request — bucket should now be known
+        await asyncio.wait_for(limiter.submit("POST", url, {"b": 2}), timeout=5.0)
+    finally:
+        await limiter.stop()
+
+    assert url in limiter._url_to_bucket
+
+
+# ---------------------------------------------------------------------------
+# 429 handling
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_429_retries_and_succeeds():
+    """A 429 response should cause the job to be retried and eventually succeed."""
+    url = "https://discord.com/api/v10/channels/1/polls/1/answers/1"
+
+    r_429 = make_mock_response(
+        status=429,
+        json_data={"retry_after": 0.01},
+        headers={"X-RateLimit-Bucket": "bucket-abc", "X-RateLimit-Remaining": "0"},
+    )
+    r_ok = make_mock_response(
+        status=200,
+        json_data={"users": []},
+        headers={"X-RateLimit-Bucket": "bucket-abc", "X-RateLimit-Remaining": "4"},
+    )
+    session = make_session(r_429, r_ok)
+
+    limiter = RateLimiter(session=session, max_retries=3)
+    limiter.start()
+
+    try:
+        status, data = await asyncio.wait_for(
+            limiter.submit("GET", url),
+            timeout=5.0,
+        )
+    finally:
+        await limiter.stop()
+
+    assert status == 200
+
+
+@pytest.mark.asyncio
+async def test_429_exceeds_max_retries_raises():
+    """Exceeding max_retries on repeated 429s should raise PollcordError."""
+    url = "https://discord.com/api/v10/channels/1/polls/1/answers/1"
+
+    responses = [
+        make_mock_response(
+            status=429,
+            json_data={"retry_after": 0.01},
+            headers={"X-RateLimit-Bucket": "bucket-abc", "X-RateLimit-Remaining": "0"},
+        )
+        for _ in range(4)
+    ]
+    session = make_session(*responses)
+
+    limiter = RateLimiter(session=session, max_retries=3)
+    limiter.start()
+
+    try:
+        with pytest.raises(PollcordError, match="Exceeded maximum retries"):
+            await asyncio.wait_for(
+                limiter.submit("GET", url),
+                timeout=5.0,
+            )
+    finally:
+        await limiter.stop()
+
+
+@pytest.mark.asyncio
+async def test_429_retry_count_is_per_job():
+    """
+    Two concurrent jobs hitting 429 should each track their own retry count.
+    One job exhausting its retries should not affect the other.
+    """
+    url_a = "https://discord.com/api/v10/channels/1/messages"
+    url_b = "https://discord.com/api/v10/channels/2/messages"
+
+    # url_a: fails twice then succeeds
+    # url_b: succeeds immediately
+    # We interleave them in the session response order
+    headers_a = {"X-RateLimit-Bucket": "bucket-a", "X-RateLimit-Remaining": "0"}
+    headers_b = {"X-RateLimit-Bucket": "bucket-b", "X-RateLimit-Remaining": "4"}
+
+    r_a_429_1 = make_mock_response(429, json_data={"retry_after": 0.01}, headers=headers_a)
+    r_a_429_2 = make_mock_response(429, json_data={"retry_after": 0.01}, headers=headers_a)
+    r_a_ok    = make_mock_response(200, json_data={"id": "1"}, headers={**headers_a, "X-RateLimit-Remaining": "4"})
+    r_b_ok    = make_mock_response(200, json_data={"id": "2"}, headers=headers_b)
+
+    # url_a goes through unknown worker first (3 calls), url_b separately
+    session = make_session(r_a_429_1, r_b_ok, r_a_429_2, r_a_ok)
+
+    limiter = RateLimiter(session=session, max_retries=5)
+    limiter.start()
+
+    try:
+        result_a, result_b = await asyncio.wait_for(
+            asyncio.gather(
+                limiter.submit("POST", url_a),
+                limiter.submit("POST", url_b),
+            ),
+            timeout=10.0,
+        )
+    finally:
+        await limiter.stop()
+
+    assert result_a[0] == 200
+    assert result_b[0] == 200
+
+
+# ---------------------------------------------------------------------------
+# Concurrent batch dispatch
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_batch_respects_remaining():
+    """
+    When remaining=3, submitting 5 jobs to the same bucket should
+    dispatch the first 3 concurrently, then the next 2 after reset.
+    """
+    url = "https://discord.com/api/v10/channels/1/messages"
+
+    # 5 successful responses — first 3 have remaining=2,1,0; last 2 have remaining=4,3
+    responses = [
+        make_mock_response(200, json_data={"id": str(i)}, headers=headers_with_remaining(max(0, 3 - i)))
+        for i in range(5)
     ]
 
-    with aioresponses() as m:
-        for i, resp in enumerate(responses):
-            m.get(f"{base}/answers/{i + 1}", status=200, payload=resp)
+    # First request goes through unknown worker to register bucket
+    first_response = make_mock_response(
+        200, json_data={"id": "first"},
+        headers=headers_with_remaining(3)
+    )
+    session = make_session(first_response, *responses)
 
-        async with PollClient(token="fake_token") as client:
-            counts = await client.get_vote_counts(poll)
+    limiter = RateLimiter(session=session, max_retries=3)
+    limiter.start()
 
-    assert counts == [2, 1, 0]
+    try:
+        # Seed the bucket
+        await asyncio.wait_for(limiter.submit("POST", url, {}), timeout=5.0)
+
+        # Now fire 5 concurrent jobs through the known bucket
+        results = await asyncio.wait_for(
+            asyncio.gather(*[limiter.submit("POST", url, {"i": i}) for i in range(5)]),
+            timeout=10.0,
+        )
+    finally:
+        await limiter.stop()
+
+    assert all(r[0] == 200 for r in results)
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_stop_cancels_workers():
+    """stop() should cancel all running worker tasks without raising."""
+    session = MagicMock()
+    limiter = RateLimiter(session=session, max_retries=3)
+    limiter.start()
+
+    assert limiter._unknown_worker_task is not None
+    assert not limiter._unknown_worker_task.done()
+
+    await limiter.stop()
+
+    assert limiter._unknown_worker_task.done()
 
 
 @pytest.mark.asyncio
-async def test_rate_limit_multiple_consecutive_429s(poll):
-    """Multiple consecutive 429s should each be respected before eventual success."""
-    url = (
-        f"https://discord.com/api/v10/channels/{poll.channel_id}"
-        f"/polls/{poll.message_id}/answers/1"
+async def test_stop_is_idempotent():
+    """Calling stop() twice should not raise."""
+    session = MagicMock()
+    limiter = RateLimiter(session=session, max_retries=3)
+    limiter.start()
+    await limiter.stop()
+    await limiter.stop()  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# Global rate limit
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_global_429_sets_pause_until():
+    """A global 429 should set _global_pause_until to a future timestamp."""
+    url = "https://discord.com/api/v10/channels/1/messages"
+
+    r_global = make_mock_response(
+        status=429,
+        json_data={"retry_after": 0.05},
+        headers={
+            "X-RateLimit-Bucket": "bucket-g",
+            "X-RateLimit-Remaining": "0",
+            "X-RateLimit-Global": "true",
+            "Retry-After": "0.05",
+        },
     )
-    success_payload = {
-        "users": [{"id": "1", "username": "alice", "discriminator": "0"}]
-    }
+    r_ok = make_mock_response(
+        status=200,
+        json_data={"ok": True},
+        headers={"X-RateLimit-Bucket": "bucket-g", "X-RateLimit-Remaining": "4"},
+    )
+    session = make_session(r_global, r_ok)
 
-    with aioresponses() as m:
-        m.get(url, status=429, payload={"retry_after": 0.01})
-        m.get(url, status=429, payload={"retry_after": 0.01})
-        m.get(url, status=200, payload=success_payload)
+    limiter = RateLimiter(session=session, max_retries=3)
+    limiter.start()
 
-        async with PollClient(token="fake_token") as client:
-            voters = await client.fetch_option_users(poll, 0, max_retries=5)
+    loop = asyncio.get_event_loop()
+    before = loop.time()
 
-    assert len(voters) == 1
+    try:
+        await asyncio.wait_for(limiter.submit("POST", url), timeout=5.0)
+    finally:
+        await limiter.stop()
+
+    assert limiter._global_pause_until >= before
+
+
+# ---------------------------------------------------------------------------
+# Window reset restores full limit
+# ---------------------------------------------------------------------------
+
+def test_window_reset_restores_full_limit():
+    """
+    After a bucket window resets, remaining should be restored to limit,
+    not just 1. This ensures the next batch can use the full capacity.
+    """
+    bucket = RateLimitBucket(bucket_id="test", remaining=0, limit=10, reset_after=0.0)
+
+    # Simulate what the bucket worker does after sleeping reset_after
+    bucket.remaining = bucket.limit
+
+    assert bucket.remaining == 10
+
+
+def test_window_reset_uses_limit_not_hardcoded_one():
+    """Verify limit=5 restores to 5, not 1."""
+    bucket = RateLimitBucket(bucket_id="test", remaining=0, limit=5, reset_after=0.0)
+    bucket.remaining = bucket.limit
+    assert bucket.remaining == 5


### PR DESCRIPTION
## le problème

ok so the old retry logic was cooked. every request had its own independent retry counter which meant if you had 20 polls all firing at once, they'd all get rate limited, all retry simultaneously, and you'd just keep losing requests until max_retries ran out. not great.

## what changed

built a proper rate limiter. requests go into a central queue, get routed to per-bucket workers (discord has separate rate limit buckets per route, so we track those), and each worker fires batches sized to whatever discord says is remaining in the current window. when a 429 hits, only that job gets requeued with its retry count incremented. everything else keeps moving.

first request to any unknown route goes solo so we can learn the bucket before letting concurrent traffic through. global rate limits (the `X-RateLimit-Global` ones) pause all workers.

`max_retries` is now a client-level setting instead of being passed per-call. was always weird that it wasn't.

also added poll persistence while i was at it. polls survive process restarts now via json on disk. scheduled end callbacks get re-registered on load. location is configurable, defaults to `polls.json` in cwd.

## what breaks

- `max_retries` param removed from `fetch_option_users`, `end_poll`, etc. set it on `PollClient(token, max_retries=5)` instead
- `get_vote_users` and `fetch_option_users` return `Voter` objects not raw dicts, so `user["id"]` becomes `user.id`
- `PollClient` now *must* be used as an async context manager, always was recommended but now the rate limiter won't start otherwise

## tests

yeah there are tests. 18 for the rate limiter alone. they mock at the session level so no real http calls.
but i haven't tested ts in prod and it'll probably break 60 million things when I attempt to acc make a bot.